### PR TITLE
replace PHP 4 style constructors for WP_Widget

### DIFF
--- a/scratch-parent/inc/widgets/blog-tabs/class-widget-blog-tabs.php
+++ b/scratch-parent/inc/widgets/blog-tabs/class-widget-blog-tabs.php
@@ -7,7 +7,7 @@ class Widget_Blog_Tabs extends WP_Widget {
 	 */
 	public function __construct() {
 		$widget_ops = array( 'description' => '' );
-		parent::WP_Widget( false, __( 'Blog Tabs', 'unyson' ), $widget_ops );
+		parent::__construct( false, __( 'Blog Tabs', 'unyson' ), $widget_ops );
 	}
 
 	/**

--- a/scratch-parent/inc/widgets/facebook-page-stream/class-widget-facebook-page-stream.php
+++ b/scratch-parent/inc/widgets/facebook-page-stream/class-widget-facebook-page-stream.php
@@ -12,7 +12,7 @@ if ( defined( 'FW' ) ) {
 			 */
 			function __construct() {
 				$widget_ops = array( 'description' => 'Page Steam' );
-				parent::WP_Widget( false, __( 'Facebook', 'unyson' ), $widget_ops );
+				parent::__construct( false, __( 'Facebook', 'unyson' ), $widget_ops );
 			}
 
 			/**

--- a/scratch-parent/inc/widgets/flickr/class-widget-flickr.php
+++ b/scratch-parent/inc/widgets/flickr/class-widget-flickr.php
@@ -7,7 +7,7 @@ class Widget_Flickr extends WP_Widget {
 	 */
 	function __construct() {
 		$widget_ops = array( 'description' => '' );
-		parent::WP_Widget( false, __( 'Flickr', 'unyson' ), $widget_ops );
+		parent::__construct( false, __( 'Flickr', 'unyson' ), $widget_ops );
 	}
 
 	/**

--- a/scratch-parent/inc/widgets/social/class-widget-social.php
+++ b/scratch-parent/inc/widgets/social/class-widget-social.php
@@ -5,7 +5,7 @@ class Widget_Social extends WP_Widget {
 	function __construct() {
 		$widget_ops = array( 'description' => __( 'Social links', 'unyson' ) );
 
-		parent::WP_Widget( false, __( 'Social', 'unyson' ), $widget_ops );
+		parent::__construct( false, __( 'Social', 'unyson' ), $widget_ops );
 	}
 
 	function widget( $args, $instance ) {

--- a/scratch-parent/inc/widgets/twitter/class-widget-twitter.php
+++ b/scratch-parent/inc/widgets/twitter/class-widget-twitter.php
@@ -11,7 +11,7 @@ if ( defined( 'FW' ) && function_exists( 'fw_ext_social_twitter_get_connection' 
 		 */
 		function __construct() {
 			$widget_ops = array( 'description' => 'Twitter Feed' );
-			parent::WP_Widget( false, __( 'Twitter', 'unyson' ), $widget_ops );
+			parent::__construct( false, __( 'Twitter', 'unyson' ), $widget_ops );
 		}
 
 		/**


### PR DESCRIPTION
Made a minor fix for the upcoming Wordpress 4.3 version.

Note: Starting in WordPress 4.3, regardless of the PHP version in use on a server, WordPress will throw a deprecated notice when one of the PHP 4 style constructors is called specifically for widgets.

More information [here](https://gist.github.com/chriscct7/d7d077afb01011b1839d).